### PR TITLE
Added filter for null comments

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,6 +106,9 @@
             var escaped_string = user_string.replace(/[\n]/g, "\\n"); //	Unescape newlines so redacting the string represents the string in the comment, literally.
             var all_comments = this.ticket().comments();
             var matched_comments = _.chain(all_comments)
+                .filter(function(comment) {
+                    return comment.value() != null;
+                })
                 .filter(function(comment) { //	Creates a new object only including comments that contain the user's desired string
                     var string = comment.value();
                     return string.indexOf(escaped_string) > -1;
@@ -130,6 +133,9 @@
             var escaped_string = user_string.replace(/[\n]/g, "\\n");
             var all_comments = this.ticket().comments();
             var matched_comments = _.chain(all_comments)
+                .filter(function(comment) {
+                    return comment.value() != null;
+                })
                 .filter(function(comment) {
                     var string = comment.value();
                     return string.indexOf(escaped_string) > -1;


### PR DESCRIPTION
Comments() object returns null for value() if comment is originally a
voicemail ticket. This filters out comments with null values before
doing any matching.
