### PR TITLE
Readme, syntax, and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An app which uses the below endpoints:
 * /api/v2/{{ticket_id}}/comments/{{comment_id}}/redact.json
 * /api/v2/{{ticket_id}}/comments/{{comment_id}}/attachments/{{attachment_id}}/redact.json
 
-The app is designed to create a simple and usable interface for Zendesk administrators to easily redact strings of text or attachments from a ticket. The intended use is to redact sensitive data, such as ID numbers, credit cards, passwords, etc... A user can copy/paste the chosen text directly from a ticket into the app and it will confirm, then perform the redaction. Attachments are redacted by selecting from a list the desired attachments, then confirming the redaction in a modal window.
+The app is designed to create a simple and usable interface for Zendesk agents and administrators to easily redact strings of text or attachments from a ticket. The intended use is to redact sensitive data, such as ID numbers, credit cards, passwords, etc... A user can copy/paste the chosen text directly from a ticket into the app and it will confirm, then perform the redaction. Attachments are redacted by selecting from a list the desired attachments, then confirming the redaction in a modal window.
 
 ## App location:
 

--- a/app.js
+++ b/app.js
@@ -47,7 +47,7 @@
         },
 
         doSomething: function() {
-            this.comments = {};
+            this.comments = [];
             var ticket_id = this.ticket().id();
             var fetchedComments = this._paginate({
                 request: 'getComments',

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,6 @@
     "defaultLocale": "en",
     "private": true,
     "location": "ticket_sidebar",
-    "version": "1.0",
+    "version": "1.1",
     "frameworkVersion": "0.5"
 }


### PR DESCRIPTION
Readme adjusted to reflect permission changes. comments = {} changed to
comments = [] to reflect that we are indeed resetting an array not an
object. Updated version number to indicate update of major changes.
