### PR TITLE
Bumping ZAF to v1.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,5 +8,5 @@
     "private": true,
     "location": "ticket_sidebar",
     "version": "1.1",
-    "frameworkVersion": "0.5"
+    "frameworkVersion": "1.0"
 }


### PR DESCRIPTION
Bumping ZAF framework version to 1.0. I missed that ZAT new will create
a 0.5 by default.
