### PR TITLE
no need to be so tall

### DIFF
--- a/app.css
+++ b/app.css
@@ -1,7 +1,6 @@
 textarea#redaction_string {
 	text-indent: 0;
 	padding: 2px;
-	min-height: 150px;
 	margin-top: 15px;
 	width: 100%;
 }

--- a/app.js
+++ b/app.js
@@ -223,7 +223,7 @@
                 }
             }
             var presentedAttachments = '<p>You will be permanently removing the below files:</p><ul class=\"redaction_img_list\">' + attachList + '</ul>'; //	HTML to inject
-            this.$('.attach_redact').modal({ //	The above funciton and iteration is a bit dirty. Can be cleaned up using something like 'var html = this.renderTemplate()'
+            this.$('.attach_redact').modal({ //	The above function and iteration is a bit dirty. Can be cleaned up using something like 'var html = this.renderTemplate()'
                 backdrop: true,
                 keyboard: false,
                 body: this.$('.modal-body div.attachPresenter').html(presentedAttachments)
@@ -300,7 +300,7 @@
         },
 
         notifyFail: function() { //	Whoops?
-            services.notify('One or more of the redactions failed...please try again', 'error');
+            services.notify('One or more of the redactions failed… please try again', 'error');
         }
     };
 

--- a/templates/text_redact.hdbs
+++ b/templates/text_redact.hdbs
@@ -2,18 +2,18 @@
   <div class="redactForm">
   {{#if can_delete}}
     <h4 class="redaction-type">Text Redaction</h4>
-    <textarea placeholder="please paste a string of text you wish to redact..."  id="redaction_string" class="redaction_string" name="redaction_string"></textarea>
+    <textarea placeholder="Paste a string of text you wish to redact."  id="redaction_string" class="redaction_string" name="redaction_string"></textarea>
     {{/if}}
     {{#if can_delete}}
-    <button class='submit_text btn'>Redact This!</button>
+    <button class='submit_text btn'>Redact Text</button>
     {{else}}
-    <span class="warn_unable">Unfortunately your role does not have access to redaction. Your administrator can change your role to allow 'ticket deletion' and enable this app</span>
+    <span class="warn_unable">Unfortunately your role does not have access to redaction. Your administrator can change your role to allow 'ticket deletion' and enable this app.</span>
     {{/if}}
   </div>
   {{#if can_delete}}
   <span class="breakline"></span>
-  <label id="attach_redact_label" for="attach_redact" class="button-label" >Do you want to redact an attachment?</label>
-  <button id="attach_redact" class="attach_redact btn" >Yes</button>
+  <label id="attach_redact_label" for="attach_redact" class="button-label" >Attachment Redaction</label>
+  <button id="attach_redact" class="attach_redact btn" >Select Attachment</button>
   {{/if}}
 
   <!--Modal for confirming text redactions -->


### PR DESCRIPTION
Generally gives the tool a bit of cleanup.

Fixes https://github.com/zendesklabs/ticket_redaction_app/issues/50

I couldn't see how to set the Attachment Redaction label to match the Text Redaction button above.

<img width="354" alt="screenshot_2293" src="https://cloud.githubusercontent.com/assets/2879972/26028777/a784ac06-37ec-11e7-911e-416588760ca7.png">
